### PR TITLE
Feature/events page

### DIFF
--- a/prisma/migrations/20240812064946_add_events_table/migration.sql
+++ b/prisma/migrations/20240812064946_add_events_table/migration.sql
@@ -1,0 +1,78 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `conversation_id` on the `Message` table. All the data in the column will be lost.
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `room_id` to the `Message` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "auth";
+
+-- AlterTable
+ALTER TABLE "public"."Match" ADD COLUMN     "room_id" TEXT NOT NULL DEFAULT gen_random_uuid();
+
+-- AlterTable
+ALTER TABLE "public"."Message" DROP COLUMN "conversation_id",
+ADD COLUMN     "room_id" TEXT NOT NULL;
+
+-- DropTable
+DROP TABLE "public"."User";
+
+-- CreateTable
+CREATE TABLE "public"."users" (
+    "user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "sex" TEXT NOT NULL,
+    "age" TEXT NOT NULL,
+    "place" TEXT NOT NULL,
+    "top_tech" TEXT NOT NULL,
+    "top_teches" TEXT[],
+    "teches" TEXT[],
+    "hobby" TEXT,
+    "occupation" TEXT NOT NULL,
+    "affiliation" TEXT,
+    "qualification" TEXT[],
+    "editor" TEXT,
+    "github" TEXT,
+    "twitter" TEXT,
+    "qiita" TEXT,
+    "zenn" TEXT,
+    "atcoder" TEXT,
+    "message" TEXT,
+    "updated_at" TIMESTAMP(3),
+    "portfolio" TEXT,
+    "graduate" TEXT,
+    "desired_occupation" TEXT,
+    "faculty" TEXT,
+    "experience" TEXT[],
+    "image_url" TEXT,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("user_id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."UserGroups" (
+    "id" TEXT NOT NULL,
+    "owner_id" TEXT NOT NULL,
+    "member_ids" TEXT[],
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+
+    CONSTRAINT "UserGroups_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Events" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "title" TEXT NOT NULL,
+    "tech_stack" TEXT[],
+    "max_participants" INTEGER NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "owner_id" TEXT NOT NULL,
+    "description" TEXT,
+
+    CONSTRAINT "Events_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20240812071116_add_events_participant_ids/migration.sql
+++ b/prisma/migrations/20240812071116_add_events_participant_ids/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Events` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "public"."Events";
+
+-- CreateTable
+CREATE TABLE "public"."Event" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "title" TEXT NOT NULL,
+    "tech_stack" TEXT[],
+    "max_participants" INTEGER NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "owner_id" TEXT NOT NULL,
+    "participant_ids" TEXT[],
+    "description" TEXT,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,10 +2,12 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
   directUrl = env("DIRECT_URL")
+  schemas  = ["auth", "public"]
 }
 
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
   binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
@@ -37,6 +39,8 @@ model users {
   faculty          String?
   experience       String[]
   image_url        String?
+
+  @@schema("public")
 }
 
 model Message {
@@ -46,6 +50,8 @@ model Message {
   receiver_id     String
   content         String
   room_id         String
+
+  @@schema("public")
 }
 
 model Match {
@@ -54,6 +60,8 @@ model Match {
   user1_id   String
   user2_id   String
   room_id    String    @default(dbgenerated("gen_random_uuid()"))
+
+  @@schema("public")
 }
 
 model Like {
@@ -61,6 +69,8 @@ model Like {
   created_at  DateTime @default(now())
   liked_user_id String
   user_id     String
+
+  @@schema("public")
 }
 
 model UserGroups {
@@ -69,4 +79,20 @@ model UserGroups {
   member_ids      String[]
   name            String
   description     String
+
+  @@schema("public")
+}
+
+model Event {
+  id               String   @id @default(uuid())
+  created_at       DateTime @default(now())
+  title            String
+  tech_stack       String[]
+  max_participants Int
+  event_type       String
+  owner_id         String
+  participant_ids  String[]
+  description      String?
+
+  @@schema("public")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import likeRoutes from "./routes/likeRoutes";
 import matchRoutes from "./routes/matchRoutes";
 import suggestRoutes from "./routes/suggestRoutes";
 import groupRoutes from "./routes/groupRoutes";
+import eventRoutes from "./routes/eventRoutes";
 import http from "http";
 import { Server as SocketIOServer, Socket } from "socket.io";
 import {
@@ -49,6 +50,7 @@ app.use("/likes", likeRoutes);
 app.use("/match", matchRoutes);
 app.use("/suggest", suggestRoutes);
 app.use("/group", groupRoutes);
+app.use("/events", eventRoutes);
 io.of("/ws/chat").on("connection", chatSocketConnection);
 io.of("/ws/group-chat").on("connection", groupChatSocketConnection);
 

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -1,0 +1,55 @@
+// src/controllers/eventController.ts
+
+import { Request, Response } from "express";
+import {
+  createEventService,
+  getAllEventsService,
+  deleteEventService,
+  joinEventService,
+} from "../services/eventService";
+import { Event } from "../models/eventModel";
+
+export const getAllEvents = async (req: Request, res: Response) => {
+  try {
+    const events: Event[] = await getAllEventsService();
+    res.status(200).json(events);
+  } catch (error) {
+    res.status(500).json({ error: "Error fetching events", details: error });
+  }
+};
+
+export const createEvent = async (req: Request, res: Response) => {
+  try {
+    const event: Event = req.body;
+    const newEvent = await createEventService(event);
+    res.status(201).json(newEvent);
+  } catch (error) {
+    res.status(500).json({ error: "Error creating event", details: error });
+  }
+};
+
+export const deleteEvent = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const { owner_id } = req.body;
+    await deleteEventService(id, owner_id);
+    res.status(204).end();
+  } catch (error) {
+    res.status(500).json({ error: "Error deleting event", details: error });
+  }
+};
+
+export const joinEvent = async (req: Request, res: Response) => {
+  try {
+    const { eventId } = req.params;
+    const { user_id } = req.body;
+    const updatedEvent: Event = await joinEventService(eventId, user_id);
+    res.status(200).json(updatedEvent);
+  } catch (error: any) {
+    if (error.message === "This event is already full") {
+      res.status(400).json({ error: "This event is already full" });
+    } else {
+      res.status(500).json({ error: "Error joining event", details: error.message });
+    }
+  }
+};

--- a/src/models/eventModel.ts
+++ b/src/models/eventModel.ts
@@ -1,0 +1,13 @@
+// src/models/eventModel.ts
+
+export type Event = {
+  id?: string;
+  created_at?: Date;
+  title: string;
+  tech_stack: string[];
+  max_participants: number;
+  event_type: string;
+  owner_id: string;
+  participant_ids: string[];
+  description: string | null;
+};

--- a/src/routes/eventRoutes.ts
+++ b/src/routes/eventRoutes.ts
@@ -1,0 +1,13 @@
+// src/routes/eventRoutes.ts
+
+import { Router } from "express";
+import { getAllEvents, createEvent, deleteEvent, joinEvent } from "../controllers/eventController";
+
+const router = Router();
+
+router.get("/get", getAllEvents);
+router.post("/create", createEvent);
+router.delete("/delete/:id", deleteEvent);
+router.post("/join/:eventId", joinEvent);
+
+export default router;

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,46 @@
+// src/services/eventService.ts
+
+import prisma from "../config/prisma";
+import { Event } from "../models/eventModel";
+
+export const getAllEventsService = async () => {
+  return await prisma.event.findMany();
+};
+
+export const createEventService = async (data: Event): Promise<Event> => {
+  return await prisma.event.create({
+    data,
+  });
+};
+
+export const deleteEventService = async (id: string, ownerId: string) => {
+  return await prisma.event.deleteMany({
+    where: {
+      id,
+      owner_id: ownerId,
+    },
+  });
+};
+
+export const joinEventService = async (eventId: string, userId: string) => {
+  const event = await prisma.event.findUnique({
+    where: { id: eventId },
+  });
+
+  if (!event) {
+    throw new Error("Event not found");
+  }
+
+  if (event.participant_ids.length >= event.max_participants) {
+    throw new Error("This event is already full");
+  }
+
+  return await prisma.event.update({
+    where: { id: eventId },
+    data: {
+      participant_ids: {
+        push: userId,
+      },
+    },
+  });
+};


### PR DESCRIPTION
Eventテーブルの追加とAPIエンドポイントの実装

- 新規Eventテーブルをデータベースに追加しました。このテーブルには、イベントのタイトル、技術スタック、最大参加人数、イベントタイプ、オーナーID、参加者IDリスト、説明などのフィールドが含まれます。
- Eventに関連するAPIエンドポイントを実装しました。以下のエンドポイントが利用可能です：
  - `GET /events/get`: すべてのイベント情報を取得します。
  - `POST /events/create`: 新しいイベントを作成します。
  - `DELETE /events/delete/:id`: オーナーのみがイベントを削除できます。
  - `POST /events/join/:eventId`: 指定したイベントにユーザーを参加させます。募集人数がすでに最大に達している場合は、参加を拒否します。