### PR TITLE
Event周りのAPIを実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,98 +1,100 @@
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
-  schemas  = ["auth", "public"]
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+  binaryTargets   = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
-generator client {
-  provider = "prisma-client-js"
-  previewFeatures = ["multiSchema"]
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+  schemas   = ["auth", "public"]
 }
 
 model users {
-  user_id          String   @id @default(uuid())
-  created_at       DateTime @default(now())
-  name             String
-  sex              String
-  age              String
-  place            String
-  top_tech         String
-  top_teches       String[]
-  teches           String[]
-  hobby            String?
-  occupation       String
-  affiliation      String?
-  qualification    String[]
-  editor           String?
-  github           String?
-  twitter          String?
-  qiita            String?
-  zenn             String?
-  atcoder          String?
-  message          String?
-  updated_at       DateTime? @updatedAt
-  portfolio        String?
-  graduate         String?
+  user_id            String    @id @default(uuid())
+  created_at         DateTime  @default(now())
+  name               String
+  sex                String
+  age                String
+  place              String
+  top_tech           String
+  top_teches         String[]
+  teches             String[]
+  hobby              String?
+  occupation         String
+  affiliation        String?
+  qualification      String[]
+  editor             String?
+  github             String?
+  twitter            String?
+  qiita              String?
+  zenn               String?
+  atcoder            String?
+  message            String?
+  updated_at         DateTime? @updatedAt
+  portfolio          String?
+  graduate           String?
   desired_occupation String?
-  faculty          String?
-  experience       String[]
-  image_url        String?
+  faculty            String?
+  experience         String[]
+  image_url          String?
 
   @@schema("public")
 }
 
 model Message {
-  id              String   @id @default(uuid())
-  created_at      DateTime @default(now())
-  sender_id       String
-  receiver_id     String
-  content         String
-  room_id         String
+  id          String   @id @default(uuid())
+  created_at  DateTime @default(now())
+  sender_id   String
+  receiver_id String
+  content     String
+  room_id     String
 
   @@schema("public")
 }
 
 model Match {
-  id         Int       @id @default(autoincrement())
-  created_at DateTime  @default(now())
+  id         Int      @id @default(autoincrement())
+  created_at DateTime @default(now())
   user1_id   String
   user2_id   String
-  room_id    String    @default(dbgenerated("gen_random_uuid()"))
+  room_id    String   @default(dbgenerated("gen_random_uuid()"))
 
   @@schema("public")
 }
 
 model Like {
-  id          Int      @id @default(autoincrement())
-  created_at  DateTime @default(now())
+  id            Int      @id @default(autoincrement())
+  created_at    DateTime @default(now())
   liked_user_id String
-  user_id     String
+  user_id       String
 
   @@schema("public")
 }
 
 model UserGroups {
-  id              String   @id @default(uuid())
-  owner_id        String
-  member_ids      String[]
-  name            String
-  description     String
+  id          String   @id @default(uuid())
+  owner_id    String
+  member_ids  String[]
+  name        String
+  description String
 
   @@schema("public")
 }
 
 model Event {
-  id               String   @id @default(uuid())
-  created_at       DateTime @default(now())
+  id               String    @id @unique @default(uuid())
+  created_at       DateTime  @default(now()) @db.Timestamptz(6)
   title            String
-  tech_stack       String[]
   max_participants Int
   event_type       String
   owner_id         String
-  participant_ids  String[]
-  description      String?
+  participant_ids  String[]  @default([])
+  purpose          String
+  deadline         DateTime  @db.Timestamptz(6)
+  updated_at       DateTime? @default(now()) @db.Timestamptz(6)
+  requirements     String
 
   @@schema("public")
 }

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -1,11 +1,11 @@
-import { createClient } from '@supabase/supabase-js';
-import { Database } from '../types/database'; // このファイルは型定義のために必要です
+import { createClient } from "@supabase/supabase-js";
+import { Database } from "../types/database";
 
-const supabaseUrl = process.env.SUPABASE_URL || '';
-const supabaseKey = process.env.SUPABASE_KEY || '';
+const supabaseUrl = process.env.SUPABASE_URL || "";
+const supabaseKey = process.env.SUPABASE_KEY || "";
 
 if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing SUPABASE_URL or SUPABASE_KEY environment variable');
+  throw new Error("Missing SUPABASE_URL or SUPABASE_KEY environment variable");
 }
 
 const supabase = createClient<Database>(supabaseUrl, supabaseKey);

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -1,55 +1,130 @@
-// src/controllers/eventController.ts
-
 import { Request, Response } from "express";
 import {
   createEventService,
-  getAllEventsService,
+  getEventByIdService,
   deleteEventService,
+  updateEventService,
   joinEventService,
+  getAllEventsService,
+  leaveEventService,
+  searchEventsByTitleService,
+  getEventsByOwnerService,
 } from "../services/eventService";
 import { Event } from "../models/eventModel";
 
-export const getAllEvents = async (req: Request, res: Response) => {
+export const createEvent = async (req: Request, res: Response) => {
   try {
-    const events: Event[] = await getAllEventsService();
-    res.status(200).json(events);
+    const eventData: Omit<Event, "id" | "created_at" | "updated_at"> = req.body;
+    const newEvent = await createEventService(eventData);
+    res.status(201).json(newEvent);
   } catch (error) {
-    res.status(500).json({ error: "Error fetching events", details: error });
+    console.error("Error in createEvent:", error);
+    res.status(500).json({ error: "Internal server error" });
   }
 };
 
-export const createEvent = async (req: Request, res: Response) => {
+export const getEventById = async (req: Request, res: Response) => {
   try {
-    const event: Event = req.body;
-    const newEvent = await createEventService(event);
-    res.status(201).json(newEvent);
+    const eventId = req.params.id;
+    const event = await getEventByIdService(eventId);
+    if (event) {
+      res.status(200).json(event);
+    } else {
+      res.status(404).json({ error: "Event not found" });
+    }
   } catch (error) {
-    res.status(500).json({ error: "Error creating event", details: error });
+    console.error("Error in getEventById:", error);
+    res.status(500).json({ error: "Internal server error" });
   }
 };
 
 export const deleteEvent = async (req: Request, res: Response) => {
   try {
-    const { id } = req.params;
-    const { owner_id } = req.body;
-    await deleteEventService(id, owner_id);
-    res.status(204).end();
+    const eventId = req.params.id;
+    const event = await getEventByIdService(eventId);
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" });
+    }
+    await deleteEventService(eventId);
+    res.status(204).send();
   } catch (error) {
-    res.status(500).json({ error: "Error deleting event", details: error });
+    console.error("Error in deleteEvent:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const updateEvent = async (req: Request, res: Response) => {
+  try {
+    const eventId = req.params.id;
+    const eventData: Partial<Event> = req.body;
+    const updatedEvent = await updateEventService(eventId, eventData);
+    res.status(200).json(updatedEvent);
+  } catch (error) {
+    console.error("Error in updateEvent:", error);
+    res.status(500).json({ error: "Internal server error" });
   }
 };
 
 export const joinEvent = async (req: Request, res: Response) => {
   try {
-    const { eventId } = req.params;
-    const { user_id } = req.body;
-    const updatedEvent: Event = await joinEventService(eventId, user_id);
+    const eventId = req.params.id;
+    const userId = req.body.userId; // ユーザーIDをリクエストボディから取得
+    const updatedEvent = await joinEventService(eventId, userId);
     res.status(200).json(updatedEvent);
-  } catch (error: any) {
-    if (error.message === "This event is already full") {
-      res.status(400).json({ error: "This event is already full" });
+  } catch (error) {
+    console.error("Error in joinEvent:", error);
+    if (error instanceof Error) {
+      res.status(400).json({ error: error.message });
     } else {
-      res.status(500).json({ error: "Error joining event", details: error.message });
+      res.status(500).json({ error: "Internal server error" });
     }
+  }
+};
+
+export const getAllEvents = async (req: Request, res: Response) => {
+  try {
+    const events = await getAllEventsService();
+    res.status(200).json(events);
+  } catch (error) {
+    console.error("Error in getAllEvents:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const leaveEvent = async (req: Request, res: Response) => {
+  try {
+    const eventId = req.params.id;
+    const userId = req.body.userId;
+    const updatedEvent = await leaveEventService(eventId, userId);
+    res.status(200).json(updatedEvent);
+  } catch (error) {
+    console.error("Error in leaveEvent:", error);
+    if (error instanceof Error) {
+      res.status(400).json({ error: error.message });
+    } else {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+};
+
+export const searchEventsByTitle = async (req: Request, res: Response) => {
+  try {
+    const title = req.query.title as string;
+    const events = await searchEventsByTitleService(title);
+    res.status(200).json(events);
+  } catch (error) {
+    console.error("Error in searchEventsByTitle:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+export const getEventsByOwner = async (req: Request, res: Response) => {
+  try {
+    const ownerId = req.params.ownerId;
+    const events = await getEventsByOwnerService(ownerId);
+    res.status(200).json(events);
+  } catch (error) {
+    console.error("Error in getEventsByOwner:", error);
+    res.status(500).json({ error: "Internal server error" });
   }
 };

--- a/src/controllers/likeController.ts
+++ b/src/controllers/likeController.ts
@@ -1,8 +1,12 @@
 import { Request, Response } from "express";
-import { createLikeService, getLikedUsersService, getUsersWhoLikedMeService, OnecreateLikeService } from "../services/likeService";
+import {
+  createLikeService,
+  getLikedUsersService,
+  getUsersWhoLikedMeService,
+  OnecreateLikeService,
+} from "../services/likeService";
 
 export const createLike = async (req: Request, res: Response) => {
-  console.log("Received data:", req.body);
   try {
     const { uuid, IDs } = req.body;
     await createLikeService(uuid, IDs);

--- a/src/models/eventModel.ts
+++ b/src/models/eventModel.ts
@@ -1,13 +1,13 @@
-// src/models/eventModel.ts
-
 export type Event = {
-  id?: string;
-  created_at?: Date;
+  id: string;
   title: string;
-  tech_stack: string[];
-  max_participants: number;
   event_type: string;
   owner_id: string;
+  max_participants: number;
   participant_ids: string[];
-  description: string | null;
+  purpose: string;
+  requirements: string;
+  deadline: Date;
+  created_at: Date;
+  updated_at: Date | null;
 };

--- a/src/routes/eventRoutes.ts
+++ b/src/routes/eventRoutes.ts
@@ -1,13 +1,26 @@
-// src/routes/eventRoutes.ts
-
 import { Router } from "express";
-import { getAllEvents, createEvent, deleteEvent, joinEvent } from "../controllers/eventController";
+import {
+  createEvent,
+  deleteEvent,
+  getEventById,
+  joinEvent,
+  updateEvent,
+  getAllEvents,
+  leaveEvent,
+  searchEventsByTitle,
+  getEventsByOwner,
+} from "../controllers/eventController";
 
 const router = Router();
 
-router.get("/get", getAllEvents);
-router.post("/create", createEvent);
-router.delete("/delete/:id", deleteEvent);
-router.post("/join/:eventId", joinEvent);
+router.post("/", createEvent);
+router.get("/", getAllEvents);
+router.get("/search", searchEventsByTitle);
+router.get("/owner/:ownerId", getEventsByOwner);
+router.get("/:id", getEventById);
+router.delete("/:id", deleteEvent);
+router.put("/:id", updateEvent);
+router.post("/:id/join", joinEvent);
+router.post("/:id/leave", leaveEvent);
 
 export default router;

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,46 +1,135 @@
-// src/services/eventService.ts
-
 import prisma from "../config/prisma";
 import { Event } from "../models/eventModel";
 
-export const getAllEventsService = async () => {
-  return await prisma.event.findMany();
-};
-
-export const createEventService = async (data: Event): Promise<Event> => {
-  return await prisma.event.create({
-    data,
-  });
-};
-
-export const deleteEventService = async (id: string, ownerId: string) => {
-  return await prisma.event.deleteMany({
-    where: {
-      id,
-      owner_id: ownerId,
-    },
-  });
-};
-
-export const joinEventService = async (eventId: string, userId: string) => {
-  const event = await prisma.event.findUnique({
-    where: { id: eventId },
-  });
-
-  if (!event) {
-    throw new Error("Event not found");
-  }
-
-  if (event.participant_ids.length >= event.max_participants) {
-    throw new Error("This event is already full");
-  }
-
-  return await prisma.event.update({
-    where: { id: eventId },
-    data: {
-      participant_ids: {
-        push: userId,
+export const createEventService = async (
+  eventData: Omit<Event, "id" | "created_at" | "updated_at">
+): Promise<Event> => {
+  try {
+    const event = await prisma.event.create({
+      data: {
+        ...eventData,
+        participant_ids: [],
       },
-    },
-  });
+    });
+    return event;
+  } catch (error) {
+    console.error("Error creating event:", error);
+    throw error;
+  }
+};
+
+export const getEventByIdService = async (eventId: string): Promise<Event | null> => {
+  try {
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+    });
+    return event;
+  } catch (error) {
+    console.error("Error getting event:", error);
+    throw error;
+  }
+};
+
+export const deleteEventService = async (eventId: string): Promise<void> => {
+  try {
+    await prisma.event.delete({
+      where: { id: eventId },
+    });
+  } catch (error) {
+    console.error("Error deleting event:", error);
+    throw error;
+  }
+};
+
+export const updateEventService = async (eventId: string, eventData: Partial<Event>): Promise<Event> => {
+  try {
+    const updatedEvent = await prisma.event.update({
+      where: { id: eventId },
+      data: eventData,
+    });
+    return updatedEvent;
+  } catch (error) {
+    console.error("Error updating event:", error);
+    throw error;
+  }
+};
+
+export const joinEventService = async (eventId: string, userId: string): Promise<Event> => {
+  try {
+    const event = await prisma.event.findUnique({
+      where: { id: eventId },
+    });
+
+    if (!event) {
+      throw new Error("Event not found");
+    }
+
+    if (event.participant_ids.includes(userId)) {
+      throw new Error("User already joined this event");
+    }
+
+    if (event.participant_ids.length >= event.max_participants) {
+      throw new Error("Event is already full");
+    }
+
+    const updatedEvent = await prisma.event.update({
+      where: { id: eventId },
+      data: {
+        participant_ids: {
+          push: userId,
+        },
+      },
+    });
+
+    return updatedEvent;
+  } catch (error) {
+    console.error("Error joining event:", error);
+    throw error;
+  }
+};
+
+export const getAllEventsService = async () => {
+  try {
+    return await prisma.event.findMany();
+  } catch (error) {
+    console.error("Error getting all events:", error);
+    throw error;
+  }
+};
+
+export const leaveEventService = async (eventId: string, userId: string): Promise<Event> => {
+  try {
+    const event = await prisma.event.findUnique({ where: { id: eventId } });
+    if (!event) throw new Error("Event not found");
+    if (!event.participant_ids.includes(userId))
+      throw new Error("User is not a participant of this event");
+
+    return await prisma.event.update({
+      where: { id: eventId },
+      data: { participant_ids: event.participant_ids.filter((id) => id !== userId) },
+    });
+  } catch (error) {
+    console.error("Error leaving event:", error);
+    throw error;
+  }
+};
+
+export const searchEventsByTitleService = async (title: string) => {
+  try {
+    return await prisma.event.findMany({
+      where: { title: { contains: title, mode: "insensitive" } },
+    });
+  } catch (error) {
+    console.error("Error searching events:", error);
+    throw error;
+  }
+};
+
+export const getEventsByOwnerService = async (ownerId: string) => {
+  try {
+    return await prisma.event.findMany({ where: { owner_id: ownerId } });
+  } catch (error) {
+    console.error("Error getting events by owner:", error);
+    throw error;
+  }
 };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2,6 +2,7 @@ import { Match } from "../models/matchModel";
 import { User } from "../models/userModel";
 import { Message } from "../models/messageModel";
 import { Like } from "../models/likeModel";
+import { Event } from "../models/eventModel";
 
 export interface Database {
   public: {
@@ -17,6 +18,9 @@ export interface Database {
       };
       Message: {
         Row: Message;
+      };
+      Event: {
+        Row: Event;
       };
     };
   };


### PR DESCRIPTION
| エンドポイント | メソッド | 説明 | 使用方法 |
|----------------|----------|------|----------|
| `/events` | POST | 新しいイベントを作成する | リクエストボディに `title`, `max_participants`, `event_type`, `owner_id`, `purpose`, `deadline`, `requirements` を含めて送信。例：<br>`{ "title": "Tech Meetup 2024", "max_participants": 50, ... }` |
| `/events` | GET | すべてのイベントの一覧を取得する | パラメータ不要。全イベントの配列が返される。 |
| `/events/:id` | GET | 指定されたIDのイベント詳細を取得する | URLの`:id`にイベントIDを指定。例：`/events/123456` |
| `/events/:id` | PUT | 指定されたIDのイベント情報を更新する | URLの`:id`にイベントIDを指定し、リクエストボディに更新したい項目を含めて送信。例：<br>`{ "max_participants": 60, "requirements": "Updated requirements" }` |
| `/events/:id` | DELETE | 指定されたIDのイベントを削除する | URLの`:id`にイベントIDを指定。 |
| `/events/:id/join` | POST | 指定されたイベントに参加する | URLの`:id`にイベントIDを指定し、リクエストボディに参加するユーザーIDを含めて送信。例：<br>`{ "userId": "user123" }` |
| `/events/:id/leave` | POST | 指定されたイベントから退出する | URLの`:id`にイベントIDを指定し、リクエストボディに退出するユーザーIDを含めて送信。例：<br>`{ "userId": "user123" }` |
| `/events/search` | GET | タイトルでイベントを検索する | クエリパラメータ`title`にキーワードを指定。例：`/events/search?title=Tech` |
| `/events/owner/:ownerId` | GET | 特定のユーザーが作成したイベント一覧を取得する | URLの`:ownerId`にユーザーIDを指定。例：`/events/owner/user123` |