### PR TITLE
Eventテーブルにtechsを追加

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,34 +12,36 @@ datasource db {
 }
 
 model users {
-  user_id            String    @id @default(uuid())
-  created_at         DateTime  @default(now())
-  name               String
-  sex                String
-  age                String
-  place              String
-  top_tech           String
-  top_teches         String[]
-  teches             String[]
-  hobby              String?
-  occupation         String
-  affiliation        String?
-  qualification      String[]
-  editor             String?
-  github             String?
-  twitter            String?
-  qiita              String?
-  zenn               String?
-  atcoder            String?
-  message            String?
-  updated_at         DateTime? @updatedAt
-  portfolio          String?
-  graduate           String?
-  desired_occupation String?
-  faculty            String?
-  experience         String[]
-  image_url          String?
-  qiita_access_token String?
+  user_id             String    @id @default(uuid())
+  created_at          DateTime  @default(now())
+  name                String
+  sex                 String
+  age                 String
+  place               String
+  top_tech            String
+  top_teches          String[]
+  teches              String[]
+  hobby               String?
+  occupation          String
+  affiliation         String?
+  qualification       String[]
+  editor              String?
+  github              String?
+  twitter             String?
+  qiita               String?
+  zenn                String?
+  atcoder             String?
+  message             String?
+  updated_at          DateTime? @updatedAt
+  portfolio           String?
+  graduate            String?
+  desired_occupation  String?
+  faculty             String?
+  experience          String[]
+  image_url           String?
+  qiita_access_token  String?
+  github_access_token String?
+  Event               Event[]
 
   @@schema("public")
 }
@@ -96,6 +98,8 @@ model Event {
   requirements     String
   updated_at       DateTime? @db.Timestamptz(6)
   deadline         DateTime  @db.Timestamptz(6)
+  techs            String[]
+  users            users     @relation(fields: [owner_id], references: [user_id], onDelete: Cascade)
 
   @@schema("public")
 }

--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -68,7 +68,7 @@ export const updateEvent = async (req: Request, res: Response) => {
 export const joinEvent = async (req: Request, res: Response) => {
   try {
     const eventId = req.params.id;
-    const userId = req.body.userId; // ユーザーIDをリクエストボディから取得
+    const userId = req.body.userId;
     const updatedEvent = await joinEventService(eventId, userId);
     res.status(200).json(updatedEvent);
   } catch (error) {

--- a/src/models/eventModel.ts
+++ b/src/models/eventModel.ts
@@ -8,6 +8,7 @@ export type Event = {
   purpose: string;
   requirements: string;
   deadline: Date;
+  techs: string[];
   created_at: Date;
   updated_at: Date | null;
 };


### PR DESCRIPTION
Eventテーブルに技術スタックであるtechsのカラムを追加しました。
型はTypeScriptで言えば、string[]です。
外部キー制約として、Eventのowner_idとusersテーブルのuser_idを設定しました。
ユーザーが削除された場合、その人がオーナーの募集も削除されます。