### PR TITLE
ランキング取得APIの実装

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import eventRoutes from "./routes/eventRoutes";
 import githubRoutes from "./routes/githubRoute";
 import qiitaRoutes from "./routes/qiitaRoutes";
 import activityRoutes from "./routes/activityRoutes";
+import rankingRoutes from "./routes/rankingRoutes";
 import http from "http";
 import { Server as SocketIOServer, Socket } from "socket.io";
 import {
@@ -60,6 +61,7 @@ app.use("/events", eventRoutes);
 app.use("/github", githubRoutes);
 app.use("/qiita", qiitaRoutes);
 app.use("/activity", activityRoutes);
+app.use("/ranking", rankingRoutes);
 io.of("/ws/chat").on("connection", chatSocketConnection);
 io.of("/ws/group-chat").on("connection", groupChatSocketConnection);
 

--- a/src/controllers/rankingController.ts
+++ b/src/controllers/rankingController.ts
@@ -1,9 +1,23 @@
 import { Request, Response } from "express";
 import {
+  getAllRankingService,
   getDailyRankingService,
   getWeeklyRankingService,
   getMonthlyRankingService
 } from "../services/rankingService";
+
+
+// 全てのランキングを取得(上位5件)
+export const getAllRanking = async (req: Request, res: Response) => {
+  try {
+    const ranking = await getAllRankingService();
+
+    res.json(ranking);
+  } catch(error) {
+    console.error("Error in getRepostitory:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
 
 // デイリーランキングを取得
 export const getDailyRanking = async (req: Request, res: Response) => {

--- a/src/controllers/rankingController.ts
+++ b/src/controllers/rankingController.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from "express";
+import {
+  getDailyRankingService,
+  getWeeklyRankingService,
+  getMonthlyRankingService
+} from "../services/rankingService";
+
+// デイリーランキングを取得
+export const getDailyRanking = async (req: Request, res: Response) => {
+  try {
+    const dailyRanking = await getDailyRankingService();
+
+    res.json(dailyRanking);
+  } catch (error) {
+    console.error("Error in getRepostitory:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+// ウィークリーランキングを取得
+export const getWeeklyRanking = async (req: Request, res: Response) => {
+  try {
+    const dailyRanking = await getWeeklyRankingService();
+
+    res.json(dailyRanking);
+  } catch (error) {
+    console.error("Error in getRepostitory:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
+
+// マンスリーランキングを取得
+export const getMonthlyRanking = async (req: Request, res: Response) => {
+  try {
+    const dailyRanking = await getMonthlyRankingService();
+
+    res.json(dailyRanking);
+  } catch (error) {
+    console.error("Error in getRepostitory:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};

--- a/src/controllers/rankingController.ts
+++ b/src/controllers/rankingController.ts
@@ -1,9 +1,10 @@
 import { Request, Response } from "express";
 import {
   getAllRankingService,
+  getTopRankingService,
   getDailyRankingService,
   getWeeklyRankingService,
-  getMonthlyRankingService
+  getMonthlyRankingService,
 } from "../services/rankingService";
 
 
@@ -18,6 +19,18 @@ export const getAllRanking = async (req: Request, res: Response) => {
     res.status(500).json({ error: "Internal server error" });
   }
 }
+
+// トップ画面用にデイリーコントリビューション数ランキング上位3人を取得
+export const getTopRanking = async (req:Request, res: Response) => {
+  try {
+    const topRanking = await getTopRankingService();
+
+    res.json(topRanking);
+  } catch (error) {
+    console.error("Error in getTopRanking:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+};
 
 // デイリーランキングを取得
 export const getDailyRanking = async (req: Request, res: Response) => {

--- a/src/controllers/rankingController.ts
+++ b/src/controllers/rankingController.ts
@@ -15,7 +15,7 @@ export const getAllRanking = async (req: Request, res: Response) => {
 
     res.json(ranking);
   } catch(error) {
-    console.error("Error in getRepostitory:", error);
+    console.error("Error in getAllRanking:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 }
@@ -39,7 +39,7 @@ export const getDailyRanking = async (req: Request, res: Response) => {
 
     res.json(dailyRanking);
   } catch (error) {
-    console.error("Error in getRepostitory:", error);
+    console.error("Error in getDailyRanking:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 };
@@ -51,7 +51,7 @@ export const getWeeklyRanking = async (req: Request, res: Response) => {
 
     res.json(dailyRanking);
   } catch (error) {
-    console.error("Error in getRepostitory:", error);
+    console.error("Error in getWeeklyRanking:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 };
@@ -63,7 +63,7 @@ export const getMonthlyRanking = async (req: Request, res: Response) => {
 
     res.json(dailyRanking);
   } catch (error) {
-    console.error("Error in getRepostitory:", error);
+    console.error("Error in getMonthlyRanking:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 };

--- a/src/routes/rankingRoutes.ts
+++ b/src/routes/rankingRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import {
+  getDailyRanking,
+  getWeeklyRanking,
+  getMonthlyRanking
+} from "../controllers/rankingController";
+
+const router = Router();
+
+router.get("/daily", getDailyRanking);
+router.get("/weekly", getWeeklyRanking);
+router.get("/monthly", getMonthlyRanking);
+
+export default router;

--- a/src/routes/rankingRoutes.ts
+++ b/src/routes/rankingRoutes.ts
@@ -1,16 +1,16 @@
 import { Router } from "express";
 import {
   getAllRanking,
+  getTopRanking,
   getDailyRanking,
   getWeeklyRanking,
-  getMonthlyRanking
+  getMonthlyRanking,
 } from "../controllers/rankingController";
 
 const router = Router();
 
-// 全てのランキングを取得(上位5件)
+router.get("/top", getTopRanking);
 router.get("/all", getAllRanking);
-
 router.get("/daily", getDailyRanking);
 router.get("/weekly", getWeeklyRanking);
 router.get("/monthly", getMonthlyRanking);

--- a/src/routes/rankingRoutes.ts
+++ b/src/routes/rankingRoutes.ts
@@ -1,11 +1,15 @@
 import { Router } from "express";
 import {
+  getAllRanking,
   getDailyRanking,
   getWeeklyRanking,
   getMonthlyRanking
 } from "../controllers/rankingController";
 
 const router = Router();
+
+// 全てのランキングを取得(上位5件)
+router.get("/all", getAllRanking);
 
 router.get("/daily", getDailyRanking);
 router.get("/weekly", getWeeklyRanking);

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -13,11 +13,12 @@ const getTopRankingNames = async (topRanking: any[]) => {
     topRanking.map(async (ranking) => {
       const user = await prisma.users.findUnique({
         where: { user_id: ranking.user_id ?? undefined },
-        select: { name: true },
+        select: { name: true, image_url:true },
       });
       return {
         ...ranking,
         name: user?.name || 'Unknown',
+        image: user?.image_url || '/img/default_icon.png'
       };
     })
   );

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -8,6 +8,7 @@ const convertIdToString = (data: any[]) => {
   }));
 };
 
+// 全てのランキングを取得(上位5件)
 export const getAllRankingService = async () => {
   try {
     const dailyContribution = await prisma.dailyGithubContributionRanking.findMany({
@@ -76,6 +77,7 @@ export const getAllRankingService = async () => {
   }
 }
 
+// デイリーランキングを取得
 export const getDailyRankingService = async () => {
   try {
     const contribution = await prisma.dailyGithubContributionRanking.findMany({
@@ -97,20 +99,9 @@ export const getDailyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = contribution.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedStar = star.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedQiita = qiita.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
+    const formattedContribution = convertIdToString(contribution);
+    const formattedStar = convertIdToString(star);
+    const formattedQiita = convertIdToString(qiita);
 
     const result = {
       contribution: formattedContribution,
@@ -124,6 +115,7 @@ export const getDailyRankingService = async () => {
   }
 };
 
+// ウィークリーランキングを取得
 export const getWeeklyRankingService = async () => {
   try {
     const contribution = await prisma.weeklyGithubContributionRanking.findMany({
@@ -145,20 +137,9 @@ export const getWeeklyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = contribution.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedStar = star.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedQiita = qiita.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
+    const formattedContribution = convertIdToString(contribution);
+    const formattedStar = convertIdToString(star);
+    const formattedQiita = convertIdToString(qiita);
 
     const result = {
       contribution: formattedContribution,
@@ -172,6 +153,7 @@ export const getWeeklyRankingService = async () => {
   }
 };
 
+// マンスリーランキングを取得
 export const getMonthlyRankingService = async () => {
   try {
     const contribution = await prisma.monthlyGithubContributionRanking.findMany({
@@ -193,20 +175,9 @@ export const getMonthlyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = contribution.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedStar = star.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
-
-    const formattedQiita = qiita.map((item) => ({
-      ...item,
-      id: item.id.toString(),
-    }));
+    const formattedContribution = convertIdToString(contribution);
+    const formattedStar = convertIdToString(star);
+    const formattedQiita = convertIdToString(qiita);
 
     const result = {
       contribution: formattedContribution,

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -1,6 +1,81 @@
 import prisma from "../config/prisma";
 
 
+const convertIdToString = (data: any[]) => {
+  return data.map(item => ({
+    ...item,
+    id: item.id.toString()
+  }));
+};
+
+export const getAllRankingService = async () => {
+  try {
+    const dailyContribution = await prisma.dailyGithubContributionRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const dailyStar = await prisma.dailyGithubContributionStarRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const dailyQiita = await prisma.dailyQiitaRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const weeklyContribution = await prisma.weeklyGithubContributionRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const weeklyStar = await prisma.weeklyGithubContributionStarRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const weeklyQiita = await prisma.weeklyQiitaRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const monthlyContribution = await prisma.monthlyGithubContributionRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const monthlyStar = await prisma.monthlyGithubContributionStarRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+    const monthlyQiita = await prisma.monthlyQiitaRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'}
+    });
+
+    // IDがBigInt型の為, string型に変換
+    const formatteddailyContribution = convertIdToString(dailyContribution);
+    const formatteddailyStar = convertIdToString(dailyStar);
+    const formatteddailyQiita = convertIdToString(dailyQiita);
+    const formattedweeklyContribution = convertIdToString(weeklyContribution);
+    const formattedweeklyStar = convertIdToString(weeklyStar);
+    const formattedweeklyQiita = convertIdToString(weeklyQiita);
+    const formattedmonthlyContribution = convertIdToString(monthlyContribution);
+    const formattedmonthlyStar = convertIdToString(monthlyStar);
+    const formattedmonthlyQiita = convertIdToString(monthlyQiita);
+
+    const result = {
+      dailyContribution: formatteddailyContribution,
+      dailyStar: formatteddailyStar,
+      dailyQiita: formatteddailyQiita,
+      weeklyContribution: formattedweeklyContribution,
+      weeklyStar: formattedweeklyStar,
+      weeklyQiita: formattedweeklyQiita,
+      monthlyContribution: formattedmonthlyContribution,
+      monthlyStar: formattedmonthlyStar,
+      monthlyQiita: formattedmonthlyQiita
+    };
+
+    return result;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+}
+
 export const getDailyRankingService = async () => {
   try {
     const contribution = await prisma.dailyGithubContributionRanking.findMany({

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -77,6 +77,22 @@ export const getAllRankingService = async () => {
   }
 }
 
+// トップ画面用にデイリーコントリビューション数ランキング上位3人を取得
+export const getTopRankingService = async () => {
+  try {
+    const topRanking = await prisma.dailyGithubContributionRanking.findMany({
+      where: {rank: {lte: 5}},
+      orderBy: {rank: 'asc'},
+    });
+
+    const formattedTopRanking = convertIdToString(topRanking);
+
+    return formattedTopRanking;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+};
+
 // デイリーランキングを取得
 export const getDailyRankingService = async () => {
   try {

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -82,19 +82,19 @@ export const getDailyRankingService = async () => {
   try {
     const contribution = await prisma.dailyGithubContributionRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const star = await prisma.dailyGithubContributionStarRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const qiita = await prisma.dailyQiitaRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
@@ -120,19 +120,19 @@ export const getWeeklyRankingService = async () => {
   try {
     const contribution = await prisma.weeklyGithubContributionRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const star = await prisma.weeklyGithubContributionStarRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const qiita = await prisma.weeklyQiitaRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
@@ -158,19 +158,19 @@ export const getMonthlyRankingService = async () => {
   try {
     const contribution = await prisma.monthlyGithubContributionRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const star = await prisma.monthlyGithubContributionStarRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 
     const qiita = await prisma.monthlyQiitaRanking.findMany({
       orderBy: {
-        rank: 'desc'
+        rank: 'asc'
       }
     });
 

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -1,0 +1,146 @@
+import prisma from "../config/prisma";
+
+
+export const getDailyRankingService = async () => {
+  try {
+    const contribution = await prisma.dailyGithubContributionRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const star = await prisma.dailyGithubContributionStarRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const qiita = await prisma.dailyQiitaRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    // IDがBigInt型の為, string型に変換
+    const formattedContribution = contribution.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedStar = star.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedQiita = qiita.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const result = {
+      contribution: formattedContribution,
+      star: formattedStar,
+      qiita: formattedQiita
+    }
+
+    return result;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+};
+
+export const getWeeklyRankingService = async () => {
+  try {
+    const contribution = await prisma.weeklyGithubContributionRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const star = await prisma.weeklyGithubContributionStarRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const qiita = await prisma.weeklyQiitaRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    // IDがBigInt型の為, string型に変換
+    const formattedContribution = contribution.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedStar = star.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedQiita = qiita.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const result = {
+      contribution: formattedContribution,
+      star: formattedStar,
+      qiita: formattedQiita
+    }
+
+    return result;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+};
+
+export const getMonthlyRankingService = async () => {
+  try {
+    const contribution = await prisma.monthlyGithubContributionRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const star = await prisma.monthlyGithubContributionStarRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    const qiita = await prisma.monthlyQiitaRanking.findMany({
+      orderBy: {
+        rank: 'desc'
+      }
+    });
+
+    // IDがBigInt型の為, string型に変換
+    const formattedContribution = contribution.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedStar = star.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const formattedQiita = qiita.map((item) => ({
+      ...item,
+      id: item.id.toString(),
+    }));
+
+    const result = {
+      contribution: formattedContribution,
+      star: formattedStar,
+      qiita: formattedQiita
+    }
+
+    return result;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+};

--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -8,6 +8,21 @@ const convertIdToString = (data: any[]) => {
   }));
 };
 
+const getTopRankingNames = async (topRanking: any[]) => {
+  return await Promise.all(
+    topRanking.map(async (ranking) => {
+      const user = await prisma.users.findUnique({
+        where: { user_id: ranking.user_id ?? undefined },
+        select: { name: true },
+      });
+      return {
+        ...ranking,
+        name: user?.name || 'Unknown',
+      };
+    })
+  );
+};
+
 // 全てのランキングを取得(上位5件)
 export const getAllRankingService = async () => {
   try {
@@ -49,15 +64,15 @@ export const getAllRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formatteddailyContribution = convertIdToString(dailyContribution);
-    const formatteddailyStar = convertIdToString(dailyStar);
-    const formatteddailyQiita = convertIdToString(dailyQiita);
-    const formattedweeklyContribution = convertIdToString(weeklyContribution);
-    const formattedweeklyStar = convertIdToString(weeklyStar);
-    const formattedweeklyQiita = convertIdToString(weeklyQiita);
-    const formattedmonthlyContribution = convertIdToString(monthlyContribution);
-    const formattedmonthlyStar = convertIdToString(monthlyStar);
-    const formattedmonthlyQiita = convertIdToString(monthlyQiita);
+    const formatteddailyContribution = convertIdToString(await getTopRankingNames(dailyContribution));
+    const formatteddailyStar = convertIdToString(await getTopRankingNames(dailyStar));
+    const formatteddailyQiita = convertIdToString(await getTopRankingNames(dailyQiita));
+    const formattedweeklyContribution = convertIdToString(await getTopRankingNames(weeklyContribution));
+    const formattedweeklyStar = convertIdToString(await getTopRankingNames(weeklyStar));
+    const formattedweeklyQiita = convertIdToString(await getTopRankingNames(weeklyQiita));
+    const formattedmonthlyContribution = convertIdToString(await getTopRankingNames(monthlyContribution));
+    const formattedmonthlyStar = convertIdToString(await getTopRankingNames(monthlyStar));
+    const formattedmonthlyQiita = convertIdToString(await getTopRankingNames(monthlyQiita));
 
     const result = {
       dailyContribution: formatteddailyContribution,
@@ -85,7 +100,7 @@ export const getTopRankingService = async () => {
       orderBy: {rank: 'asc'},
     });
 
-    const formattedTopRanking = convertIdToString(topRanking);
+    const formattedTopRanking = convertIdToString(await getTopRankingNames(topRanking));
 
     return formattedTopRanking;
   } catch(error: any) {
@@ -115,9 +130,9 @@ export const getDailyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = convertIdToString(contribution);
-    const formattedStar = convertIdToString(star);
-    const formattedQiita = convertIdToString(qiita);
+    const formattedContribution = convertIdToString(await getTopRankingNames(contribution));
+    const formattedStar = convertIdToString(await getTopRankingNames(star));
+    const formattedQiita = convertIdToString(await getTopRankingNames(qiita));
 
     const result = {
       contribution: formattedContribution,
@@ -153,9 +168,9 @@ export const getWeeklyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = convertIdToString(contribution);
-    const formattedStar = convertIdToString(star);
-    const formattedQiita = convertIdToString(qiita);
+    const formattedContribution = convertIdToString(await getTopRankingNames(contribution));
+    const formattedStar = convertIdToString(await getTopRankingNames(star));
+    const formattedQiita = convertIdToString(await getTopRankingNames(qiita));
 
     const result = {
       contribution: formattedContribution,
@@ -191,9 +206,9 @@ export const getMonthlyRankingService = async () => {
     });
 
     // IDがBigInt型の為, string型に変換
-    const formattedContribution = convertIdToString(contribution);
-    const formattedStar = convertIdToString(star);
-    const formattedQiita = convertIdToString(qiita);
+    const formattedContribution = convertIdToString(await getTopRankingNames(contribution));
+    const formattedStar = convertIdToString(await getTopRankingNames(star));
+    const formattedQiita = convertIdToString(await getTopRankingNames(qiita));
 
     const result = {
       contribution: formattedContribution,


### PR DESCRIPTION
ランキング取得のAPIを実装しました。
APIルートは以下になります。
`/ranking/top`：トップ画面用にデイリーコントリビューション数ランキング上位3件を取得
`/ranking/all`：すべてのランキングを取得(上位5件)
`/ranking/daily`：デイリーランキングを取得
`/ranking/weekly`：ウィークリーランキングを取得
`/ranking/monthly`：マンスリーランキングを取得