### PR TITLE
ランク・レベルの計算APIを実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,6 +42,9 @@ model users {
   qiita_access_token  String?
   github_access_token String?
   github_username     String?
+  rank                String?
+  level               String?
+  next_level_points   String?
   Event               Event[]
 
   @@schema("public")
@@ -546,6 +549,42 @@ model TimelineReaction {
 
   @@index([post_id], map: "idx_timeline_reaction_post_id")
   @@index([user_id], map: "idx_timeline_reaction_user_id")
+  @@schema("public")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+model DailyGeekLinkActivity {
+  id             BigInt    @id @default(autoincrement())
+  created_at     DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime? @default(now()) @db.Timestamp(6)
+  user_id        String?   @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  activity_score Int?
+  rank           Int?
+
+  @@schema("public")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+model MonthlyGeekLinkActivity {
+  id             BigInt    @id @default(autoincrement())
+  created_at     DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime? @default(now()) @db.Timestamp(6)
+  user_id        String?   @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  activity_score Int?
+  rank           Int?
+
+  @@schema("public")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+model WeeklyGeekLinkActivity {
+  id             BigInt    @id @default(autoincrement())
+  created_at     DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime? @default(now()) @db.Timestamp(6)
+  user_id        String?   @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  activity_score Int?
+  rank           Int?
+
   @@schema("public")
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import eventRoutes from "./routes/eventRoutes";
 import githubRoutes from "./routes/githubRoute";
 import qiitaRoutes from "./routes/qiitaRoutes";
 import activityRoutes from "./routes/activityRoutes";
+import rankRoutes from "./routes/rankRoutes";
 import http from "http";
 import { Server as SocketIOServer, Socket } from "socket.io";
 import {
@@ -60,6 +61,7 @@ app.use("/events", eventRoutes);
 app.use("/github", githubRoutes);
 app.use("/qiita", qiitaRoutes);
 app.use("/activity", activityRoutes);
+app.use("/rank", rankRoutes);
 io.of("/ws/chat").on("connection", chatSocketConnection);
 io.of("/ws/group-chat").on("connection", groupChatSocketConnection);
 

--- a/src/controllers/rankController.ts
+++ b/src/controllers/rankController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+import { getUserRankService } from "../services/rankService";
+
+export const getUserRank = async (req: Request, res: Response) => {
+  const { uuid } = req.body;
+  try {
+    const result = await getUserRankService(uuid);
+    
+    res.json(result);
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error", details: error });
+  }
+};

--- a/src/controllers/rankController.ts
+++ b/src/controllers/rankController.ts
@@ -1,5 +1,16 @@
 import { Request, Response } from "express";
-import { getUserRankService } from "../services/rankService";
+import { getUserRankService, updateUserRankService } from "../services/rankService";
+ 
+export const updateUserRank = async (req: Request, res: Response) => {
+  const { uuid } = req.body;
+  try {
+    const result = await updateUserRankService(uuid);
+
+    res.json(result)
+  } catch(error) {
+    res.status(500).json({ error: "Internal Server Error", details: error });
+  }
+}
 
 export const getUserRank = async (req: Request, res: Response) => {
   const { uuid } = req.body;

--- a/src/graphql/queries/getUserGithub.ts
+++ b/src/graphql/queries/getUserGithub.ts
@@ -165,3 +165,16 @@ export const getUseLanguageQuery = `
     }
   }
 `;
+
+// ユーザーの総コントリビューション数を取得(ランク計算に使用)
+export const getTotalContributionsQuery = `
+  query getTotalContributionsQuery($username: String!) {
+    user(login: $username) {
+      contributionsCollection {
+        contributionCalendar {
+          totalContributions
+        }
+      }
+    }
+  }
+`;

--- a/src/models/userModel.ts
+++ b/src/models/userModel.ts
@@ -28,6 +28,9 @@ export type User = {
   image_url?: string;
   qiita_access_token?: string;
   github_access_token?: string;
+  rank?: string;
+  level?: string;
+  next_level_points?: string;
 };
 
 export type TopUserResponse = {

--- a/src/routes/rankRoutes.ts
+++ b/src/routes/rankRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
-import { getUserRank } from "../controllers/rankController";
+import { updateUserRank, getUserRank } from "../controllers/rankController";
 
 const router = Router();
 
+router.post("/update", updateUserRank);
 router.post("/user", getUserRank);
 
 export default router;

--- a/src/routes/rankRoutes.ts
+++ b/src/routes/rankRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getUserRank } from "../controllers/rankController";
+
+const router = Router();
+
+router.post("/user", getUserRank);
+
+export default router;

--- a/src/services/rankService.ts
+++ b/src/services/rankService.ts
@@ -111,7 +111,6 @@ const calculateUserLevel = (contributions: number, totalQiitaPosts: number, tota
   const postPoints = totalAppPosts * 6.0;
 
   const totalPoints = contributionPoints + qiitaPoints + eventPoints + postPoints;
-  console.log(totalPoints)
 
   // 経験値の上限は10,000(1レベルあたり100)
   // 次のレベルまでの経験値も返す   
@@ -137,7 +136,7 @@ const calculateUserLevel = (contributions: number, totalQiitaPosts: number, tota
 
 
 const calculateUserRank = (level: number): string => {
-  const ranks = ["Master", "DiamondI", "DiamondⅡ", "DiamondⅢ", "PlatinumI", "PlatinumⅡ", "PlatinumⅢ", "GoldI", "GoldⅡ", "GoldⅢ", "SilverI", "SilverⅡ", "SilverⅢ", "BronzeI", "BronzeⅡ", "BronzeⅢ", "Normal"];
+  const ranks = ["Legend", "MasterI", "MasterⅡ", "MasterⅢ", "DiamondI", "DiamondⅡ", "DiamondⅢ", "GoldI", "GoldⅡ", "GoldⅢ", "SilverI", "SilverⅡ", "SilverⅢ", "BronzeI", "BronzeⅡ", "BronzeⅢ"];
 
   switch (true) {
     case (level >= 95):
@@ -160,19 +159,17 @@ const calculateUserRank = (level: number): string => {
       return ranks[8];
     case (level >= 50):
       return ranks[9];
-    case (level >= 45):
-      return ranks[10];
     case (level >= 40):
-      return ranks[11];
+      return ranks[10];
     case (level >= 30):
-      return ranks[12];
+      return ranks[11];
     case (level >= 20):
-      return ranks[13];
+      return ranks[12];
     case (level >= 10):
-      return ranks[14];
+      return ranks[13];
     case (level >= 5):
-      return ranks[15];
+      return ranks[14];
     default:
-      return ranks[16];
+      return ranks[15];
   }
 };

--- a/src/services/rankService.ts
+++ b/src/services/rankService.ts
@@ -58,18 +58,6 @@ export const getUserRankService = async (uuid: string) => {
     // レベルの計算ロジック
     const { level, nextLevelPoints } = calculateUserLevel(contributions, totalQiitaPosts, totalOwnerEvents, totalAppPosts);
 
-    // コントリビューション数, Qiitaの投稿数, イベントの作成数, アプリ内投稿数
-    // レベル90以上の人
-    console.log("Lv90目安：Level",calculateUserLevel(1800,7,3,50))
-    // レベル70ぐらいの人
-    console.log("Lv70目安：Level",calculateUserLevel(1200,5,2,45))
-    // レベル50ぐらいの人
-    console.log("Lv50目安：Level",calculateUserLevel(800,3,1,40))
-    // レベル30ぐらいの人
-    console.log("Lv30目安：Level",calculateUserLevel(400,2,0,30))
-    // レベル10ぐらいの人
-    console.log("Lv10目安：Level",calculateUserLevel(100,1,0,20))
-
     // ランクの計算ロジック
     const rank = calculateUserRank(level);
 

--- a/src/services/rankService.ts
+++ b/src/services/rankService.ts
@@ -1,0 +1,173 @@
+import { getUserGithubInfo } from "./githubService";
+import { graphql } from "../graphql/graphql";
+import { getTotalContributionsQuery } from "../graphql/queries/getUserGithub";
+import { contributionResponse } from "../types/githubInterface";
+import prisma from "../config/prisma";
+import axios from "axios";
+
+export const getUserRankService = async (uuid: string) => {
+  try {
+    // レベルの計算に必要な情報の取得
+    // 総コントリビューション数の取得
+    const { username, token } = await getUserGithubInfo(uuid);
+    const contributionResponse = await graphql(
+        getTotalContributionsQuery,
+        { username },
+        token
+    );
+    const contributions = (contributionResponse as contributionResponse).user.contributionsCollection.contributionCalendar.totalContributions;
+
+    // Qiitaの総投稿数を取得
+    const user = await prisma.users.findUnique({
+      where: { user_id: uuid },
+      select: {
+          qiita_access_token: true,
+          qiita: true,
+      },
+    });
+  
+    if (!user) {
+    throw new Error("User not found");
+    }
+
+    const { qiita_access_token, qiita } = user;
+  
+    // ユーザーの投稿情報を取得
+    const response = await axios.get(
+      `https://qiita.com/api/v2/users/${qiita}/items`,
+      {
+        headers: {
+        Authorization: `Bearer ${qiita_access_token}`,
+        },
+      }
+    );
+    const totalQiitaPosts = response.data.length;
+
+    // イベントの投稿数を取得
+    const ownerEvents = await prisma.event.findMany({
+        where: uuid ? {owner_id: uuid} : undefined,
+    });
+    const totalOwnerEvents = ownerEvents.length;
+
+    // タイムラインへの投稿数を取得
+    const appPosts = await prisma.timeline.findMany({
+        where: {user_id: uuid},
+    });
+    const totalAppPosts = appPosts.length;
+
+    // レベルの計算ロジック
+    const { level, nextLevelPoints } = calculateUserLevel(contributions, totalQiitaPosts, totalOwnerEvents, totalAppPosts);
+
+    // コントリビューション数, Qiitaの投稿数, イベントの作成数, アプリ内投稿数
+    // レベル90以上の人
+    console.log("Lv90目安：Level",calculateUserLevel(1800,7,3,50))
+    // レベル70ぐらいの人
+    console.log("Lv70目安：Level",calculateUserLevel(1200,5,2,45))
+    // レベル50ぐらいの人
+    console.log("Lv50目安：Level",calculateUserLevel(800,3,1,40))
+    // レベル30ぐらいの人
+    console.log("Lv30目安：Level",calculateUserLevel(400,2,0,30))
+    // レベル10ぐらいの人
+    console.log("Lv10目安：Level",calculateUserLevel(100,1,0,20))
+
+    // ランクの計算ロジック
+    const rank = calculateUserRank(level);
+
+    const result = {
+      rank: rank,
+      level: level,
+      nextLevelPoints: nextLevelPoints
+    }
+
+    return result;
+  } catch(error: any) {
+    throw new Error(error.message);
+  }
+}
+
+const calculateUserLevel = (contributions: number, totalQiitaPosts: number, totalOwnerEvents: number, totalAppPosts: number): { level: number, nextLevelPoints: number } => {
+  let points = 0;
+
+  // 各要素に応じて経験値を計算
+  // コントリビューション数が増えるほど経験値の上がり幅は小さく⇒コントリビューション数が少ない, 開発初心者は上がり幅を大きく 
+  if (contributions >= 1500) {
+    points += contributions * 5.0;
+  } else if (contributions >= 1000) {
+    points += contributions * 5.5;
+  } else if (contributions >= 750) {
+    points += contributions * 6.0;
+  } else if (contributions >= 500) {
+    points += contributions * 6.5;
+  } else if (contributions >= 300) {
+    points += contributions * 7.0;
+  } else if (contributions >= 150) {
+    points += contributions * 8.0;
+  } else {
+    points += contributions * 9.0;
+  }
+  points += totalQiitaPosts * 20.0;
+  points += totalOwnerEvents * 20.0;
+  points += totalAppPosts * 6.0;
+
+  // 経験値の上限は10,000(1レベルあたり100)
+  // 次のレベルまでの経験値も返す   
+  const nextLevelPoints = Math.floor(1000 - (points % 1000));
+
+  const level = Math.floor(points / 100);
+
+  // レベルが100以上の場合は100を返す(最大が100)  
+  if (level >= 100) {
+    return {
+      level: 100,
+      nextLevelPoints: 0 
+    }
+  };
+
+  const result = {
+    level: level,
+    nextLevelPoints: nextLevelPoints
+  };
+
+  return result;
+};
+
+const calculateUserRank = (level: number): string => {
+  const ranks = ["Master", "DiamondI", "DiamondⅡ", "DiamondⅢ", "PlatinumI", "PlatinumⅡ", "PlatinumⅢ", "GoldI", "GoldⅡ", "GoldⅢ", "SilverI", "SilverⅡ", "SilverⅢ", "BronzeI", "BronzeⅡ", "BronzeⅢ", "Normal"];
+
+  switch (true) {
+    case (level >= 95):
+      return ranks[0];
+    case (level >= 90):
+      return ranks[1];
+    case (level >= 85):
+      return ranks[2];
+    case (level >= 80):
+      return ranks[3];
+    case (level >= 75):
+      return ranks[4];
+    case (level >= 70):
+      return ranks[5];
+    case (level >= 65):
+      return ranks[6];
+    case (level >= 60):
+      return ranks[7];
+    case (level >= 55):
+      return ranks[8];
+    case (level >= 50):
+      return ranks[9];
+    case (level >= 45):
+      return ranks[10];
+    case (level >= 40):
+      return ranks[11];
+    case (level >= 30):
+      return ranks[12];
+    case (level >= 20):
+      return ranks[13];
+    case (level >= 10):
+      return ranks[14];
+    case (level >= 5):
+      return ranks[15];
+    default:
+      return ranks[16];
+  }
+};

--- a/src/services/rankService.ts
+++ b/src/services/rankService.ts
@@ -111,10 +111,11 @@ const calculateUserLevel = (contributions: number, totalQiitaPosts: number, tota
   const postPoints = totalAppPosts * 6.0;
 
   const totalPoints = contributionPoints + qiitaPoints + eventPoints + postPoints;
+  console.log(totalPoints)
 
   // 経験値の上限は10,000(1レベルあたり100)
   // 次のレベルまでの経験値も返す   
-  const nextLevelPoints = Math.floor(1000 - (totalPoints % 1000));
+  const nextLevelPoints = Math.floor(100 - (totalPoints % 100));
 
   const level = Math.floor(totalPoints / 100);
 

--- a/src/services/rankService.ts
+++ b/src/services/rankService.ts
@@ -58,6 +58,17 @@ export const getUserRankService = async (uuid: string) => {
     // レベルの計算ロジック
     const { level, nextLevelPoints } = calculateUserLevel(contributions, totalQiitaPosts, totalOwnerEvents, totalAppPosts);
 
+    // レベル90以上の人
+    console.log("Lv90目安：Level",calculateUserLevel(1900,7,3,50))
+    // レベル70ぐらいの人
+    console.log("Lv70目安：Level",calculateUserLevel(1300,5,2,45))
+    // レベル50ぐらいの人
+    console.log("Lv50目安：Level",calculateUserLevel(800,3,1,40))
+    // レベル30ぐらいの人
+    console.log("Lv30目安：Level",calculateUserLevel(400,2,0,30))
+    // レベル10ぐらいの人
+    console.log("Lv10目安：Level",calculateUserLevel(100,1,0,20))
+
     // ランクの計算ロジック
     const rank = calculateUserRank(level);
 
@@ -74,34 +85,36 @@ export const getUserRankService = async (uuid: string) => {
 }
 
 const calculateUserLevel = (contributions: number, totalQiitaPosts: number, totalOwnerEvents: number, totalAppPosts: number): { level: number, nextLevelPoints: number } => {
-  let points = 0;
-
   // 各要素に応じて経験値を計算
   // コントリビューション数が増えるほど経験値の上がり幅は小さく⇒コントリビューション数が少ない, 開発初心者は上がり幅を大きく 
-  if (contributions >= 1500) {
-    points += contributions * 5.0;
-  } else if (contributions >= 1000) {
-    points += contributions * 5.5;
-  } else if (contributions >= 750) {
-    points += contributions * 6.0;
-  } else if (contributions >= 500) {
-    points += contributions * 6.5;
-  } else if (contributions >= 300) {
-    points += contributions * 7.0;
-  } else if (contributions >= 150) {
-    points += contributions * 8.0;
-  } else {
-    points += contributions * 9.0;
-  }
-  points += totalQiitaPosts * 20.0;
-  points += totalOwnerEvents * 20.0;
-  points += totalAppPosts * 6.0;
+  const contributionPoints = (() => {
+    if (contributions >= 1500) {
+      return contributions * 4.5;
+    } else if (contributions >= 1000) {
+      return contributions * 5.0;
+    } else if (contributions >= 750) {
+      return contributions * 6.0;
+    } else if (contributions >= 500) {
+      return contributions * 6.5;
+    } else if (contributions >= 300) {
+      return contributions * 7.0;
+    } else if (contributions >= 150) {
+      return contributions * 8.0;
+    } else {
+      return contributions * 9.0;
+    }
+  })();
+  const qiitaPoints = totalQiitaPosts * 20.0;
+  const eventPoints = totalOwnerEvents * 20.0;
+  const postPoints = totalAppPosts * 6.0;
+
+  const totalPoints = contributionPoints + qiitaPoints + eventPoints + postPoints;
 
   // 経験値の上限は10,000(1レベルあたり100)
   // 次のレベルまでの経験値も返す   
-  const nextLevelPoints = Math.floor(1000 - (points % 1000));
+  const nextLevelPoints = Math.floor(1000 - (totalPoints % 1000));
 
-  const level = Math.floor(points / 100);
+  const level = Math.floor(totalPoints / 100);
 
   // レベルが100以上の場合は100を返す(最大が100)  
   if (level >= 100) {


### PR DESCRIPTION
ランク・レベルの計算APIを実装しました。

### 計算ロジックの詳細
レベルの最大は100
総経験値は10,000とし、1レベルあたり100経験値が必要

#### 経験値 = コントリビューション数 * (4.5~9.0) + Qiita投稿数 * 20.0 + イベント作成数 * 20.0 + アプリ内投稿数 * 6.0

※コントリビューション数に応じて経験値(レベル)の上昇幅を調整
　コントリビューション数が多いと上昇幅は小さく、コントリビューション数が少ないと上昇幅は大きく


適当にパラメータを設定した結果が以下になります。

```
calculateUserLevel(コントリビューション数、Qiita投稿数、イベント作成数、アプリ内投稿数)

// レベル90以上の人
calculateUserLevel(1900,7,3,50)　 // 結果：level: 90
// レベル70ぐらいの人
calculateUserLevel(1300,5,2,45)　 // 結果：level: 69
// レベル50ぐらいの人
calculateUserLevel(800,3,1,40)　  // 結果：level: 51
// レベル30ぐらいの人
calculateUserLevel(400,2,0,30)　  // 結果：level: 30
// レベル10ぐらいの人
calculateUserLevel(100,1,0,20)　  // 結果：level: 10
```
