### PR TITLE
トップで取得するランキング取得件数を5人から3人に修正

### DIFF
--- a/src/services/rankingService.ts
+++ b/src/services/rankingService.ts
@@ -97,7 +97,7 @@ export const getAllRankingService = async () => {
 export const getTopRankingService = async () => {
   try {
     const topRanking = await prisma.dailyGithubContributionRanking.findMany({
-      where: {rank: {lte: 5}},
+      where: {rank: {lte: 3}},
       orderBy: {rank: 'asc'},
     });
 


### PR DESCRIPTION
トップで取得するランキング取得件数が本来3人のはずが5人にしてしまっていたため修正しました。
軽微な修正のため即マージします。