### PR TITLE
いいねからフォロー機能へのリプレイス

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,13 +194,14 @@ model mfa_amr_claims {
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model mfa_challenges {
-  id          String      @id @db.Uuid
-  factor_id   String      @db.Uuid
-  created_at  DateTime    @db.Timestamptz(6)
-  verified_at DateTime?   @db.Timestamptz(6)
-  ip_address  String      @db.Inet
-  otp_code    String?
-  mfa_factors mfa_factors @relation(fields: [factor_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "mfa_challenges_auth_factor_id_fkey")
+  id                     String      @id @db.Uuid
+  factor_id              String      @db.Uuid
+  created_at             DateTime    @db.Timestamptz(6)
+  verified_at            DateTime?   @db.Timestamptz(6)
+  ip_address             String      @db.Inet
+  otp_code               String?
+  web_authn_session_data Json?
+  mfa_factors            mfa_factors @relation(fields: [factor_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "mfa_challenges_auth_factor_id_fkey")
 
   @@index([created_at(sort: Desc)], map: "mfa_challenge_created_at_idx")
   @@schema("auth")
@@ -209,18 +210,20 @@ model mfa_challenges {
 /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model mfa_factors {
-  id                 String           @id @db.Uuid
-  user_id            String           @db.Uuid
-  friendly_name      String?
-  factor_type        factor_type
-  status             factor_status
-  created_at         DateTime         @db.Timestamptz(6)
-  updated_at         DateTime         @db.Timestamptz(6)
-  secret             String?
-  phone              String?
-  last_challenged_at DateTime?        @unique @db.Timestamptz(6)
-  mfa_challenges     mfa_challenges[]
-  users              auth_users       @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id                   String           @id @db.Uuid
+  user_id              String           @db.Uuid
+  friendly_name        String?
+  factor_type          factor_type
+  status               factor_status
+  created_at           DateTime         @db.Timestamptz(6)
+  updated_at           DateTime         @db.Timestamptz(6)
+  secret               String?
+  phone                String?
+  last_challenged_at   DateTime?        @unique @db.Timestamptz(6)
+  web_authn_credential Json?
+  web_authn_aaguid     String?          @db.Uuid
+  mfa_challenges       mfa_challenges[]
+  users                auth_users       @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([user_id, phone], map: "unique_phone_factor_per_user")
   @@index([user_id, created_at], map: "factor_id_created_at_idx")
@@ -586,6 +589,16 @@ model WeeklyGeekLinkActivity {
   user_id        String?   @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   activity_score Int?
   rank           Int?
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model follows {
+  id          BigInt   @id @default(autoincrement())
+  follower_id String
+  followee_id String
+  created_at  DateTime @default(now()) @db.Timestamptz(6)
 
   @@schema("public")
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import qiitaRoutes from "./routes/qiitaRoutes";
 import activityRoutes from "./routes/activityRoutes";
 import rankRoutes from "./routes/rankRoutes";
 import rankingRoutes from "./routes/rankingRoutes";
+import followRoutes from "./routes/followRoutes";
 import http from "http";
 import { Server as SocketIOServer } from "socket.io";
 import {
@@ -63,6 +64,7 @@ app.use("/qiita", qiitaRoutes);
 app.use("/activity", activityRoutes);
 app.use("/rank", rankRoutes);
 app.use("/ranking", rankingRoutes);
+app.use("/follow", followRoutes);
 io.of("/ws/chat").on("connection", chatSocketConnection);
 io.of("/ws/group-chat").on("connection", groupChatSocketConnection);
 

--- a/src/controllers/followController.ts
+++ b/src/controllers/followController.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from "express";
+import {
+  addFollowService,
+  deleteFollowService,
+  getFollowNumService,
+  getFollowsService,
+} from "../services/followService";
+
+// ランダムマッチングからフォローされた場合
+export const addFollow = async (req: Request, res: Response) => {
+  try {
+    const { uuid, IDs } = req.body;
+    for (const id of IDs) {
+      await addFollowService(uuid, id);
+    }
+    await addFollowService(uuid, IDs);
+    res.status(200).json({ message: "Follows created successfully" });
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error", details: error });
+  }
+};
+
+export const deleteFollow = async (req: Request, res: Response) => {
+  try {
+    const { uuid, ID } = req.body;
+    await deleteFollowService(uuid, ID);
+    res.status(200).json({ message: "Follows deleted successfully" });
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error", details: error });
+  }
+};
+
+export const getFollowNum = async (req: Request, res: Response) => {
+  const { uuid } = req.body;
+  try {
+    const users = await getFollowNumService(uuid);
+    res.status(200).json(users);
+  } catch(error) {
+    res.status(500).json({ error: "Error fetching followed users" });
+  }
+}
+  
+export const getFollows = async (req: Request, res: Response) => {
+  const { uuid } = req.body;
+  try {
+    const users = await getFollowsService(uuid);
+    res.status(200).json(users);
+  } catch (error) {
+    res.status(500).json({ error: "Error fetching followed users" });
+  }
+};
+
+// ユーザーページからフォローされた場合
+export const addFollowOne = async (req: Request, res: Response) => {
+  try {
+    const { uuid, ID } = req.body;
+    await addFollowService(uuid, ID);
+    res.status(200).json({ message: "Likes created successfully" });
+  } catch (error) {
+    res.status(500).json({ error: "Internal Server Error", details: error });
+  }
+};

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -2,7 +2,7 @@ import { Request, Response } from "express";
 import {
   getProfileService,
   updateProfileService,
-  LikeStatusCheck,
+  followStatusCheck,
 } from "../services/profileService";
 
 export const updateProfile = async (req: Request, res: Response) => {
@@ -33,15 +33,15 @@ export const getProfile = async (req: Request, res: Response) => {
   }
 };
 
-export const LikeStatus = async (req: Request, res: Response) => {
+export const followStatus = async (req: Request, res: Response) => {
   try {
     const { myID, uuid } = req.body;
-    const likeStatus = await LikeStatusCheck(myID, uuid);
+    const followStatus = await followStatusCheck(myID, uuid);
     res
       .status(200)
-      .json({ message: "likeStatus check successfully", data: likeStatus });
+      .json({ message: "followStatus check successfully", data: followStatus });
   } catch (error) {
-    console.error("Error check likeStatus", error);
+    console.error("Error check followStatus", error);
     res.status(500).json({ error: "Internal Server Error" });
   }
 };

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,15 +2,15 @@ import { Request, Response } from "express";
 import {
   checkUserExistsService,
   getFilterUsers,
-  getMatchingUsersService,
+  getMutualFollowUsersService,
   getMessagesAndRoomService,
 } from "../services/userService";
 import { getLatestMessages } from "../services/messageService";
 
-export const getMatchingUsers = async (req: Request, res: Response) => {
+export const getMutualFollowUsers = async (req: Request, res: Response) => {
   const { uuid } = req.body;
   try {
-    const users = await getMatchingUsersService(uuid);
+    const users = await getMutualFollowUsersService(uuid);
     res.status(200).json(users);
   } catch (error) {
     res.status(500).json({ error: "Internal server error" });

--- a/src/models/followModel.ts
+++ b/src/models/followModel.ts
@@ -1,0 +1,6 @@
+export type Follow = {
+  id?: number;
+  follower_id: string;
+  followee_id: string;
+  created_at: Date;
+};

--- a/src/routes/followRoutes.ts
+++ b/src/routes/followRoutes.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import {
+  addFollow,
+  deleteFollow,
+  getFollowNum,
+  getFollows,
+  addFollowOne,
+} from "../controllers/followController";
+
+const router = Router();
+
+router.post("/add-follow", addFollow);
+router.post("/delete-follow", deleteFollow);
+router.post("/get-follows-num", getFollowNum);
+router.post("/get-follows", getFollows);
+router.post("/add-follow-one", addFollowOne);
+
+export default router;

--- a/src/routes/profileRoutes.ts
+++ b/src/routes/profileRoutes.ts
@@ -1,10 +1,10 @@
 import { Router } from "express";
-import { getProfile, updateProfile, LikeStatus } from "../controllers/profileController";
+import { getProfile, updateProfile, followStatus } from "../controllers/profileController";
 
 const router = Router();
 
 router.post("/update-profile", updateProfile);
 router.get("/get-profile/:uuid", getProfile);
-router.post("/like-status", LikeStatus)
+router.post("/follow-status", followStatus)
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -2,14 +2,14 @@ import { Router } from "express";
 import {
   checkUserExists,
   filterUsers,
-  getMatchingUsers,
+  getMutualFollowUsers,
   getMessages,
   getLatestMessage,
 } from "../controllers/userController";
 
 const router = Router();
 
-router.post("/get-matching-users", getMatchingUsers);
+router.post("/get-mutual-follow-users", getMutualFollowUsers);
 router.get("/get-messages", getMessages);
 router.post("/check-user-exists", checkUserExists);
 router.post("/filter-users", filterUsers);

--- a/src/services/followService.ts
+++ b/src/services/followService.ts
@@ -1,0 +1,127 @@
+import prisma from "../config/prisma";
+import { Follow } from "../models/followModel";
+
+// フォローする
+export const addFollowService = async (uuid: string, ID: string): Promise<void> => {
+  const user_id = uuid;
+  const other_user_id = ID;
+
+  const row: Follow = {
+    follower_id: user_id,
+    followee_id: other_user_id,
+    created_at: new Date(),
+  };
+
+  try {
+    await prisma.follows.create({
+      data: row,
+    });
+  } catch (error: any) {
+    throw new Error(error.message);
+  };
+};
+
+// フォローを取り消す
+export const deleteFollowService = async (uuid: string, ID: string): Promise<void> => {
+  const user_id = uuid;
+  const other_user_id = ID;
+
+  try {
+    await prisma.follows.deleteMany({
+      where: {
+        follower_id: user_id,
+        followee_id: other_user_id,
+      },
+    });
+  } catch (error: any) {
+    throw new Error(error.message);
+  };
+};
+
+export const getFollowNumService = async (uuid: string) => {
+  try {
+    // 自分がフォローしているユーザーを取得(フォロー)
+    const follows = await prisma.follows.findMany({
+      where: {
+        follower_id: uuid,
+      },
+    });
+
+    // 自分をフォローしているユーザーを取得(フォロワー)
+    const followers = await prisma.follows.findMany({
+      where: {
+        followee_id: uuid,
+      },
+    });
+
+    const result = {
+      followsNum: follows.length,
+      followersNum: followers.length,
+    }
+
+    return result;
+  } catch (error: any) {
+    throw new Error(error.message);
+  };
+};
+
+
+// ユーザーのフォロー・フォロワーを取得
+export const getFollowsService = async (uuid: string) => {
+  try {
+    // 自分がフォローしているユーザーを取得(フォロー)
+    const follows = await prisma.follows.findMany({
+      where: {
+        follower_id: uuid,
+      },
+    });
+
+    const followIds = follows.map(follow => follow.followee_id);
+
+    const followUsers = await prisma.users.findMany({
+      where: {
+        user_id: {
+          in: followIds,
+        },
+      },
+      select: {
+        user_id: true,
+        name: true,
+        image_url: true,
+      },
+    });
+
+    // 自分をフォローしているユーザーを取得(フォロワー)
+    const followers = await prisma.follows.findMany({
+      where: {
+        followee_id: uuid,
+      },
+    });
+
+    const followerIds = followers.map(follow => follow.follower_id);
+
+    const followerUsers = await prisma.users.findMany({
+      where: {
+        user_id: {
+          in: followerIds,
+        },
+      },
+      select: {
+        user_id: true,
+        name: true,
+        image_url: true,
+      },
+    });
+
+    const result = {
+      followsNum: follows.length,
+      followersNum: followers.length,
+      follows: followUsers,
+      followers: followerUsers,
+    };
+
+    return result;
+  } catch (error: any) {
+    throw new Error(error.message);
+  };
+};

--- a/src/services/matchService.ts
+++ b/src/services/matchService.ts
@@ -1,14 +1,20 @@
 import { users as PrismaUser } from "@prisma/client";
 import prisma from "../config/prisma";
 
-export const getRandomMatchesService = async (
-  user_id: string
-): Promise<PrismaUser[]> => {
+export const getRandomMatchesService = async (user_id: string): Promise<PrismaUser[]> => {
   try {
+    const follows = await prisma.follows.findMany({
+      where: {
+        follower_id: user_id,
+      },
+    });
+    
+    const followIds = follows.map(follow => follow.followee_id);
+    
     const users = await prisma.users.findMany({
       where: {
         user_id: {
-          not: user_id,
+          notIn: [user_id, ...followIds],
         },
       },
     });

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -31,15 +31,12 @@ export const getProfileService = async (
   }
 };
 
-export const LikeStatusCheck = async (
-  user_id: string,
-  other_user_id: string
-) => {
+export const followStatusCheck = async (user_id: string, other_user_id: string) => {
   try {
-    const result = await prisma.like.findFirst({
+    const result = await prisma.follows.findFirst({
       where: {
-        user_id: user_id,
-        liked_user_id: other_user_id,
+        follower_id: user_id,
+        followee_id: other_user_id,
       },
     });
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,5 +1,5 @@
 import prisma from "../config/prisma";
-import { users, Message, Match } from "@prisma/client";
+import { users, Message, follows } from "@prisma/client";
 
 
 export const getUserDataService = async (
@@ -16,25 +16,31 @@ export const getUserDataService = async (
 };
 
 
-export const getMatchingUsersService = async (
+export const getMutualFollowUsersService = async (
   uuid: string
 ): Promise<users[]> => {
-  // MatchテーブルからマッチしたユーザーのIDを取得
-  const matches = await prisma.match.findMany({
+  const following = await prisma.follows.findMany({
     where: {
-      OR: [{ user1_id: uuid }, { user2_id: uuid }],
+      follower_id: uuid,
     },
   });
 
-  const matchedUserIds = matches.flatMap((match: Match) =>
-    match.user1_id === uuid ? match.user2_id : match.user1_id
-  );
+  const followers = await prisma.follows.findMany({
+    where: {
+      followee_id: uuid,
+    },
+  });
+
+  // 相互フォローのユーザーIDを取得
+  const followingIds = following.map(follow => follow.followee_id);
+  const followerIds = followers.map(follow => follow.follower_id);
+  const mutualFollowIds = followingIds.filter(id => followerIds.includes(id));
 
   // Userテーブルからマッチしたユーザーの情報を取得
   const matchedUsers: users[] = await prisma.users.findMany({
     where: {
       user_id: {
-        in: matchedUserIds,
+        in: mutualFollowIds,
       },
     },
   });

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -4,6 +4,7 @@ import { Message } from "../models/messageModel";
 import { Like } from "../models/likeModel";
 import { Event } from "../models/eventModel";
 import { Timeline } from "../models/timelineModel";
+import { Follow } from "../models/followModel";
 
 export interface Database {
   public: {
@@ -25,6 +26,9 @@ export interface Database {
       };
       Timeline: {
         Row: Timeline;
+      };
+      Follow: {
+        Row: Follow;
       };
     };
   };


### PR DESCRIPTION
やったこと
・followテーブルの追加
・いいねからフォロー機能へのリプレイス
　・自身がフォローしている・フォローされている人の一覧を返すAPIを追加
　・自身のフォロー・フォロワー数を返すAPIを追加
・ランダムマッチングで既にフォローしているユーザーは表示しないように修正

以前のいいね・マッチング機能で使っていたlikeテーブルとmatchテーブルは後日消す予定です