### PR TITLE
ユーザー初期登録の際の判定を修正

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,15 +14,15 @@ datasource db {
 model users {
   user_id             String    @id @default(uuid())
   created_at          DateTime  @default(now())
-  name                String
-  sex                 String
-  age                 String
-  place               String
-  top_tech            String
+  name                String    @default("")
+  sex                 String    @default("")
+  age                 String    @default("")
+  place               String    @default("")
+  top_tech            String    @default("")
   top_teches          String[]
   teches              String[]
   hobby               String?
-  occupation          String
+  occupation          String    @default("")
   affiliation         String?
   qualification       String[]
   editor              String?

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -85,7 +85,9 @@ export const checkUserExistsService = async (user_id: string): Promise<boolean> 
     },
   });
 
-  return !!user;
+  // nameの初期値をEMPTYに設定しているため,
+  // 初期登録ができていても名前の変更がまだ(プロフィールの設定がこれから)の場合はfalse
+  return !!user && user.name !== "";
 };
 
 // 出身地を引数に取り、その出身地のユーザーを取得する関数


### PR DESCRIPTION
やったこと
・usersのNOT NULLフィールドの初期値をNULLからEMPTYに変更
・プロフィールの初期設定をするかのAPIでnameがEMPTYだった場合を追加し対応